### PR TITLE
Number cast error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1
+
+- Fixed error in `numberCast` of `math` library.
+
+---
+
 ## 0.1.0
 
 - Initial version.

--- a/lib/src/math/basic/comparison.dart
+++ b/lib/src/math/basic/comparison.dart
@@ -34,12 +34,17 @@ T numberCast<T extends num>(dynamic obj) {
 
   // Convert obj to a numeric value.
   num? n;
-  if (obj is num) n = obj;
-  if (obj == null || obj == false) n = 0;
-  if (obj == true) n = 1;
-  if (obj is Points) n = obj.total;
-  if (obj is BaseRadix) n = obj.number;
-  if (obj is String) {
+  if (obj is num) {
+    n = obj;
+  } else if (obj == null || obj == false) {
+    n = 0;
+  } else if (obj == true) {
+    n = 1;
+  } else if (obj is Points) {
+    n = obj.total;
+  } else if (obj is BaseRadix) {
+    n = obj.number;
+  } else if (obj is String) {
     n = double.tryParse(obj);
     if (n == null) {
       if (obj.isEmpty) {

--- a/lib/src/math/basic/comparison.dart
+++ b/lib/src/math/basic/comparison.dart
@@ -68,8 +68,8 @@ T numberCast<T extends num>(dynamic obj) {
   }
 
   // ensure that n is the correct numeric type.
-  if (T is int) return n.toInt() as T;
-  if (T is double) return n.toDouble() as T;
+  if (T == int) return n.toInt() as T;
+  if (T == double) return n.toDouble() as T;
 
   // Falls to here only because T isn't a known extention of num
   // or is num itself.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,10 @@
 name: dartora
 description: A large utility package.
-version: 0.1.0
+version: 0.1.1
 homepage: https://officer-erik-1k-88.github.io/dartora/
 repository: https://github.com/Officer-Erik-1K-88/dartora
 issue_tracker: https://github.com/Officer-Erik-1K-88/dartora/issues
+documentation: https://officer-erik-1k-88.github.io/dartora/doc/Overview
 
 topics:
   - utilities


### PR DESCRIPTION
Fixed an error in `numberCast` of the math lib that prevented it from ensuring that the given object was cast into the correct number type.